### PR TITLE
Fix losing physics after setting pose

### DIFF
--- a/AirLib/include/physics/PhysicsBody.hpp
+++ b/AirLib/include/physics/PhysicsBody.hpp
@@ -161,6 +161,9 @@ public: //methods
     }
     void setPose(const Pose& pose)
     {
+        // the `grounded_` is set true when starting playing, 
+        // but it is expected to be false when clients tried setting pose.
+        grounded_ = false;
         return kinematics_->setPose(pose);
     }
     const Twist& getTwist() const


### PR DESCRIPTION
This fixed the problem that after using simSetVehiclePose in multirotor mode, the drone can't be controlled by most of the commands.